### PR TITLE
Include nested exceptions for LAST_EXCEPTION

### DIFF
--- a/src/web/Content/client/analysis.py
+++ b/src/web/Content/client/analysis.py
@@ -589,7 +589,7 @@ class LastExceptionAnalyzer(AnalysisEngine):
     def analyze(self, dictProps, dictArgs):
         thread = g_dbg.target.GetProcess().GetSelectedThread()
         sos = SosInterpreter()
-        peOut = sos.pe()
+        peOut = sos.pe(True)
         dictProps['LAST_EXCEPTION'] = peOut
         peProps = _str_to_dict(peOut)
         if 'Exception type' in peProps and peProps['Exception type'] is not None:


### PR DESCRIPTION
Currently output from a dump is not including details on inner exceptions.
This is particularly frustrating now that Debug.Assert fail fasts, which
generates an ExecutionEngineException that contains the actual debug
exception as the inner exception... seeing the results from that inner
exception make quickly debugging much easier.

cc: @schaabs, @jkotas, @mellinoe 