### PR TITLE
Fix file position cursor

### DIFF
--- a/src/web/Controllers/DumplingApiController.cs
+++ b/src/web/Controllers/DumplingApiController.cs
@@ -331,7 +331,7 @@ namespace dumpling.web.Controllers
                     using (var compStream = CreateTempFile())
                     {
                         await blob.DownloadToStreamAsync(compStream, cancelToken);
-
+                        compStream.Position = 0;
                         using (var gunzipStream = new GZipStream(compStream, CompressionMode.Decompress, false))
                         {
                             await gunzipStream.CopyToAsync(tempStream);


### PR DESCRIPTION
When we would attempt to build the archive for the uploaded dump we
first download the individual pieces of the archive. When we were doing
this we never reset the position of the cursor in the file. As a result
when we would go to encode the files in the new archive we would start
at the end of the file and put zero length files in the archive.

This changes simply resets the cursor position at the beginning of the
stream after we download it and before we add it to the new stream.